### PR TITLE
issue/2 additional display configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # adapt-navigationLogo
 
-Displays an image in the course navigation bar.
+Displays an image in the course navigation bar. Image can be configured to utilise three different sizings (small, large, and fill), whether the image should display on small screens, and if the image should be shown on a small screen whether an alternative, more mobile friendly, version should be used.
+
+AT Compatible.
+
+### Attributes
 
 #### Course
 
@@ -8,13 +12,13 @@ Displays an image in the course navigation bar.
 
 >**\_isEnabled** (boolean): Controls whether the Navigation Logo course object is enabled or not.
 
-**\_graphic** (object): The image that constitutes the logo. It contains values for **alt**, **_src**, and **_mobileSrc**.
+>**\_graphic** (object): The image that constitutes the logo. It contains values for **src**, **_mobileSrc**, and **alt**.
 
->**alt** (string): This text becomes the image’s `alt` attribute.
+>>**src** (string): File name (including path) of the logo image displayed at all device widths.
 
->**_src** (string): File name (including path) of the logo image displayed at all device widths.
+>>**_mobileSrc** (string): Optional, file name (including path) of the logo image used to display an alternative image for mobile view. Useful for displaying a smaller logo.
 
->**_mobileSrc** (string): Optional, file name (including path) of the logo image used to display an alternative image for mobile view. Useful for displaying a smaller logo.
+>>**alt** (string): This text becomes the image’s `alt` attribute.
 
 >**\_logoSize** (string): This defines the size and padding of the logo image. Acceptable values are `small`, `large` or `fill`. Default value is `large`.
 
@@ -24,8 +28,13 @@ Displays an image in the course navigation bar.
 + Remember to include an **alt** attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.
 
 ## Limitations
+
 No known limitations
-AT Compatible
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera
+
+----------------------------
+**Version number:**  2.2.0  
+**Framework versions:**  5+  
+**Author / maintainer:** CGKineo  
+**Accessibility support:** WAI AA  
+**RTL support:** Yes  
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # adapt-navigationLogo
 
-Displays an image in the course navigation bar. Image can be configured to utilise three different sizings (small, large, and fill), whether the image should display on small screens, and if the image should be shown on a small screen whether an alternative, more mobile friendly, version should be used.
+Displays an image in the course navigation bar. Image displays with minimal padding by default or can be configured to fill the navigation bar height. Other options include whether an alternative, more mobile friendly, version should be used. Or hide the image for mobile view.
 
 AT Compatible.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
 # adapt-navigationLogo
 
+Displays an image in the course navigation bar.
+
+#### Course
+
+**\_navigationLogo** (object): The course.json Navigation Logo target attribute object.
+
+>**\_isEnabled** (boolean): Controls whether the Navigation Logo course object is enabled or not.
+
+**\_graphic** (object): The image that constitutes the logo. It contains values for **alt**, **_src**, and **_mobileSrc**.
+
+>**alt** (string): This text becomes the image’s `alt` attribute.
+
+>**_src** (string): File name (including path) of the logo image displayed at all device widths.
+
+>**_mobileSrc** (string): Optional, file name (including path) of the logo image used to display an alternative image for mobile view. Useful for displaying a smaller logo.
+
+>**\_logoSize** (string): This defines the size and padding of the logo image. Acceptable values are `small`, `large` or `fill`. Default value is `large`.
+
+>**\_hideLogoForMobile** (boolean): Optional, hide logo for mobile view. Useful to declutter the navigation bar for mobile view where limited space is available.
+
+## Accessibility
++ Remember to include an **alt** attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.
+
+## Limitations
+No known limitations
 AT Compatible
-Accessible
+**Accessibility support:** WAI AA
+**RTL support:** Yes
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AT Compatible.
 No known limitations
 
 ----------------------------
-**Version number:**  2.2.0  
+**Version number:**  2.1.0  
 **Framework versions:**  5+  
 **Author / maintainer:** CGKineo  
 **Accessibility support:** WAI AA  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AT Compatible.
 
 >>**alt** (string): This text becomes the image’s `alt` attribute.
 
->**\_logoSize** (string): This defines the size and padding of the logo image. Acceptable values are `small`, `large` or `fill`. Default value is `large`.
+>**\_fillNavHeight** (boolean): False by default, logo displays with minimal padding. Set to true for logo to fill the nav bar height.
 
 >**\_hideLogoForMobile** (boolean): Optional, hide logo for mobile view. Useful to declutter the navigation bar for mobile view where limited space is available.
 

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "adapt-navigationLogo",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "framework": ">=5",
   "homepage": "https://github.com/cgkineo/adapt-navigationLogo",
-  "extension" : "navigationLogo",
-  "displayName" : "Navigation Logo",
-  "description": "Navigation Logo",
+  "extension": "navigationLogo",
+  "displayName": "Navigation Logo",
+  "description": "Displays an image in the course navigation bar.",
   "main": "/js/adapt-navigationLogo.js",
   "keywords": [
     "adapt-plugin",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-navigationLogo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "framework": ">=5",
   "homepage": "https://github.com/cgkineo/adapt-navigationLogo",
   "extension": "navigationLogo",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-navigationLogo",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "framework": ">=5",
   "homepage": "https://github.com/cgkineo/adapt-navigationLogo",
   "extension": "navigationLogo",

--- a/example.json
+++ b/example.json
@@ -6,7 +6,6 @@
             "_mobileSrc": "",
             "alt": ""
         },
-        "_comment": "Supported _logoSize classes = 'small', 'large', 'fill'",
-        "_logoSize": "large",
+        "_fillNavHeight": false,
         "_hideLogoForMobile": true
     }

--- a/example.json
+++ b/example.json
@@ -2,7 +2,7 @@
     "_navigationLogo": {
         "_isEnabled": true,
         "_graphic": {
-            "_src": "",
+            "src": "assets/example.png",
             "_mobileSrc": "",
             "alt": ""
         },

--- a/example.json
+++ b/example.json
@@ -1,8 +1,12 @@
-//course.json
+    // course.json
     "_navigationLogo": {
         "_isEnabled": true,
         "_graphic": {
-            "src": "",
-            "alt": "Company Logo"
-        }
+            "_src": "",
+            "_mobileSrc": "",
+            "alt": ""
+        },
+        "_comment": "Supported _logoSize classes = 'small', 'large', 'fill'",
+        "_logoSize": "large",
+        "_hideLogoForMobile": true
     }

--- a/js/LogoView.js
+++ b/js/LogoView.js
@@ -16,12 +16,12 @@ define([
     },
 
     postRender: function() {
-      var config = Adapt.course.get("_navigationLogo");
-      if (config && config._hideLogoForMobile) {
+      var config = this.model.get('_graphic');
+      if (this.model.get('_hideLogoForMobile')) {
         this.hideLogoForMobile();
       }
-      if (config && config._graphic._mobileSrc) {
-        this.setLogoImageSrc();
+      if (config && config._mobileSrc) {
+        this.setLogoImageSrc(config);
       }
     },
 
@@ -30,8 +30,7 @@ define([
       $(".navigation-logo__image").toggleClass('u-display-none', isDeviceSmall);
     },
 
-    setLogoImageSrc: function() {
-      var config = this.model.get('_graphic');
+    setLogoImageSrc: function(config) {
       var src = Adapt.device.screenSize === 'small' ? config._mobileSrc : config.src;
 
       $('.navigation-logo__image').attr('src', src);

--- a/js/LogoView.js
+++ b/js/LogoView.js
@@ -8,11 +8,47 @@ define([
 
     initialize: function() {
       this.render();
+      this.listenTo(Adapt, "device:changed", this.onDeviceResize);
+    },
+
+    onDeviceResize: function() {
+      this.postRender();
+    },
+
+    postRender: function() {
+      var config = Adapt.course.get("_navigationLogo");
+      if (config && config._hideLogoForMobile) {
+        this.hideLogoForMobile();
+      }
+      if (config && config._graphic._mobileSrc) {
+        this.setLogoImageSrc();
+      }
+    },
+
+    hideLogoForMobile: function() {
+      (Adapt.device.screenSize === 'small')
+        // mobile logo display
+        ? $(".navigation-logo__image").addClass('u-display-none')
+        // desktop logo display
+        : $(".navigation-logo__image").removeClass('u-display-none');
+    },
+
+    setLogoImageSrc: function() {
+      var config = Adapt.course.get("_navigationLogo");
+      var mobileSrc = config._graphic._mobileSrc;
+      var src = config._graphic._src;
+      (Adapt.device.screenSize === 'small')
+        // mobile logo display
+        ? $(".navigation-logo__image").attr('src', mobileSrc)
+        // desktop logo display
+        : $(".navigation-logo__image").attr('src', src);
     },
 
     render: function() {
       var data = this.model.toJSON();
       this.$el.html(Handlebars.templates[this.constructor.template](data));
+      _.defer(this.postRender.bind(this));
+      return this;
     }
 
   },{

--- a/js/LogoView.js
+++ b/js/LogoView.js
@@ -26,22 +26,15 @@ define([
     },
 
     hideLogoForMobile: function() {
-      (Adapt.device.screenSize === 'small')
-        // mobile logo display
-        ? $(".navigation-logo__image").addClass('u-display-none')
-        // desktop logo display
-        : $(".navigation-logo__image").removeClass('u-display-none');
+      var isDeviceSmall = Adapt.device.screenSize === 'small';
+      $(".navigation-logo__image").toggleClass('u-display-none', isDeviceSmall);
     },
 
     setLogoImageSrc: function() {
-      var config = Adapt.course.get("_navigationLogo");
-      var mobileSrc = config._graphic._mobileSrc;
-      var src = config._graphic._src;
-      (Adapt.device.screenSize === 'small')
-        // mobile logo display
-        ? $(".navigation-logo__image").attr('src', mobileSrc)
-        // desktop logo display
-        : $(".navigation-logo__image").attr('src', src);
+      var config = this.model.get('_graphic');
+      var src = Adapt.device.screenSize === 'small' ? config._mobileSrc : config.src;
+
+      $('.navigation-logo__image').attr('src', src);
     },
 
     render: function() {

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -21,7 +21,6 @@ define([
 
       var selector = ".js-nav-back-btn";
       this.logoView.$el.insertAfter($(selector));
-
     }
 
   });

--- a/less/navigationLogo.less
+++ b/less/navigationLogo.less
@@ -3,23 +3,27 @@
 
   // pre-set logo sizes
   // displays 'large' by default
-  .large {
+
+  // Large logo display
+  .is-large {
     padding: @icon-padding / 2;
-
-    .navigation-logo__image {
-      height: @icon-size + @icon-padding;
-    }
   }
 
-  .small {
+  .is-large &__image {
+    height: @icon-size + @icon-padding;
+  }
+
+  // Small logo display
+  .is-small {
     padding: @icon-padding;
-
-    .navigation-logo__image {
-      height: @icon-size;
-    }
   }
 
-  .fill &__image {
+  .is-small &__image {
+    height: @icon-size;
+  }
+
+  // Fill logo display
+  .is-fill &__image {
     height: @icon-size + (@icon-padding * 2);
   }
 }

--- a/less/navigationLogo.less
+++ b/less/navigationLogo.less
@@ -1,10 +1,25 @@
-
 .navigation-logo {
   .u-float-left;
-  height: @icon-size + (@icon-padding * 2);
-  padding: @icon-padding;
 
-  &__image {
-    height: @icon-size;
+  // pre-set logo sizes
+  // displays 'large' by default
+  .large {
+    padding: @icon-padding / 2;
+
+    .navigation-logo__image {
+      height: @icon-size + @icon-padding;
+    }
+  }
+
+  .small {
+    padding: @icon-padding;
+
+    .navigation-logo__image {
+      height: @icon-size;
+    }
+  }
+
+  .fill &__image {
+    height: @icon-size + (@icon-padding * 2);
   }
 }

--- a/less/navigationLogo.less
+++ b/less/navigationLogo.less
@@ -1,28 +1,16 @@
 .navigation-logo {
   .u-float-left;
 
-  // pre-set logo sizes
-  // displays 'large' by default
-
-  // Large logo display
-  .is-large {
+  // default display
+  &__inner:not(.is-fill) {
     padding: @icon-padding / 2;
   }
 
-  .is-large &__image {
+  &__image {
     height: @icon-size + @icon-padding;
   }
 
-  // Small logo display
-  .is-small {
-    padding: @icon-padding;
-  }
-
-  .is-small &__image {
-    height: @icon-size;
-  }
-
-  // Fill logo display
+  // fill nav height display
   .is-fill &__image {
     height: @icon-size + (@icon-padding * 2);
   }

--- a/properties.schema
+++ b/properties.schema
@@ -55,7 +55,7 @@
                       "title": "Logo image alternative text",
                       "inputType": "Text",
                       "validators": [],
-                      "help": "The alternative text for this image.",
+                      "help": "Provide alternative text for the image, such as your company name. This text is not a visible element. It is utilized by assistive technology such as screen readers. Avoid identifying the logo as actually being a logo.",
                       "translatable": true
                     }
                   }

--- a/properties.schema
+++ b/properties.schema
@@ -20,7 +20,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Enable Navigation Logo?",
+                  "title": "Add logo to navigation bar",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Set to true to enable the 'Navigation Logo' feature."

--- a/properties.schema
+++ b/properties.schema
@@ -73,7 +73,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Hide Logo for mobile view",
+                  "title": "Hide logo for mobile view",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Useful to declutter the navigation bar for mobile view where limited space is available."

--- a/properties.schema
+++ b/properties.schema
@@ -23,7 +23,7 @@
                   "title": "Add logo to navigation bar",
                   "inputType": "Checkbox",
                   "validators": [],
-                  "help": "Set to true to enable the 'Navigation Logo' feature."
+                  "help": ""
                 },
                 "_graphic": {
                   "type": "object",

--- a/properties.schema
+++ b/properties.schema
@@ -60,23 +60,20 @@
                     }
                   }
                 },
-                "_logoSize": {
-                  "type": "string",
+                "_fillNavHeight": {
+                  "type": "boolean",
                   "required": false,
-                  "default": "large",
-                  "title": "Set the size of the logo image",
-                  "inputType": {
-                    "type": "Select",
-                    "options": ["small", "large", "fill"]
-                  },
+                  "default": false,
+                  "title": "Logo fills the nav bar height",
+                  "inputType": "Checkbox",
                   "validators": [],
-                  "help": "Small: Logo image displays at the same size as navigation icons. Large: Logo image displays larger than navigation icons leaving small space around the logo. Fill: Logo image fills the height of the navigation bar."
+                  "help": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height."
                 },
                 "_hideLogoForMobile": {
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Hide Navigation Logo for mobile view",
+                  "title": "Hide Logo for mobile view",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Useful to declutter the navigation bar for mobile view where limited space is available."

--- a/properties.schema
+++ b/properties.schema
@@ -29,14 +29,23 @@
                   "required":true,
                   "title": "Logo image",
                   "properties":{
-                    "src": {
+                    "_src": {
                       "type": "string",
                       "required": true,
                       "default": "",
                       "title": "Image",
                       "inputType": "Asset:image",
                       "validators": ["required"],
-                      "help": "The provided logo must be 24px high"
+                      "help": "The provided logo must be 24px high minimum."
+                    },
+                    "_mobileSrc": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Optional mobile image",
+                      "inputType": "Asset:image",
+                      "validators": ["required"],
+                      "help": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum."
                     },
                     "alt": {
                       "type": "string",
@@ -45,10 +54,26 @@
                       "title": "Logo image alternative Text",
                       "inputType": "Text",
                       "validators": [],
-                      "help": "The alternative text for this image",
+                      "help": "The alternative text for this image.",
                       "translatable": true
                     }
                   }
+                },
+                "_logoSize": {
+                  "type": "string",
+                  "required": false,
+                  "default": "large",
+                  "inputType": {"type":"Select", "options":["small","large","fill"]},
+                  "title": "Set the size of the logo image",
+                  "help": "Small: Logo image displays at the same size as navigation icons. Large: Logo image displays larger than navigation icons leaving small space arounf the logo. Fill: Logo image fills the height of the navigation bar."
+                },
+                "_hideLogoForMobile": {
+                  "type": "boolean",
+                  "required": false,
+                  "title": "Hide Navigation Logo for mobile view",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Useful to declutter the navigation bar for mobile view where limited space is available."
                 }
               }
             }

--- a/properties.schema
+++ b/properties.schema
@@ -52,7 +52,7 @@
                       "type": "string",
                       "required": false,
                       "default": "",
-                      "title": "Logo image alternative Text",
+                      "title": "Logo image alternative text",
                       "inputType": "Text",
                       "validators": [],
                       "help": "The alternative text for this image.",

--- a/properties.schema
+++ b/properties.schema
@@ -19,23 +19,24 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "title": "Enable Navigation Logo",
+                  "default": false,
+                  "title": "Enable Navigation Logo?",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Set to true to enable the 'Navigation Logo' feature."
                 },
                 "_graphic": {
-                  "type":"object",
-                  "required":true,
+                  "type": "object",
+                  "required": true,
                   "title": "Logo image",
-                  "properties":{
-                    "_src": {
+                  "properties": {
+                    "src": {
                       "type": "string",
-                      "required": true,
+                      "required": false,
                       "default": "",
                       "title": "Image",
                       "inputType": "Asset:image",
-                      "validators": ["required"],
+                      "validators": [],
                       "help": "The provided logo must be 24px high minimum."
                     },
                     "_mobileSrc": {
@@ -44,7 +45,7 @@
                       "default": "",
                       "title": "Optional mobile image",
                       "inputType": "Asset:image",
-                      "validators": ["required"],
+                      "validators": [],
                       "help": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum."
                     },
                     "alt": {
@@ -63,13 +64,18 @@
                   "type": "string",
                   "required": false,
                   "default": "large",
-                  "inputType": {"type":"Select", "options":["small","large","fill"]},
                   "title": "Set the size of the logo image",
-                  "help": "Small: Logo image displays at the same size as navigation icons. Large: Logo image displays larger than navigation icons leaving small space arounf the logo. Fill: Logo image fills the height of the navigation bar."
+                  "inputType": {
+                    "type": "Select",
+                    "options": ["small", "large", "fill"]
+                  },
+                  "validators": [],
+                  "help": "Small: Logo image displays at the same size as navigation icons. Large: Logo image displays larger than navigation icons leaving small space around the logo. Fill: Logo image fills the height of the navigation bar."
                 },
                 "_hideLogoForMobile": {
                   "type": "boolean",
                   "required": false,
+                  "default": false,
                   "title": "Hide Navigation Logo for mobile view",
                   "inputType": "Checkbox",
                   "validators": [],

--- a/properties.schema
+++ b/properties.schema
@@ -64,7 +64,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Logo fills the nav bar height",
+                  "title": "Make logo fill navigation bar height",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height."

--- a/templates/navigationLogo.hbs
+++ b/templates/navigationLogo.hbs
@@ -1,3 +1,3 @@
-<div class="navigation-logo__inner is-{{_logoSize}}">
+<div class="navigation-logo__inner{{#if _fillNavHeight}} is-fill{{/if}}">
   <img class="navigation-logo__image" src="{{_graphic.src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}" {{else}}aria-hidden="true" {{/if}}>
 </div>

--- a/templates/navigationLogo.hbs
+++ b/templates/navigationLogo.hbs
@@ -1,4 +1,3 @@
-<div class="navigation-logo__inner {{_logoSize}}">
-  <img class="navigation-logo__image" src="{{_graphic._src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}"
-    {{else}}aria-hidden="true" {{/if}}>
+<div class="navigation-logo__inner is-{{_logoSize}}">
+  <img class="navigation-logo__image" src="{{_graphic.src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}" {{else}}aria-hidden="true" {{/if}}>
 </div>

--- a/templates/navigationLogo.hbs
+++ b/templates/navigationLogo.hbs
@@ -1,1 +1,4 @@
-<img class="navigation-logo__image" src="{{_graphic.src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}"{{else}}aria-hidden="true"{{/if}}>
+<div class="navigation-logo__inner {{_logoSize}}">
+  <img class="navigation-logo__image" src="{{_graphic._src}}" {{#if _graphic.alt}}aria-label="{{_graphic.alt}}"
+    {{else}}aria-hidden="true" {{/if}}>
+</div>


### PR DESCRIPTION
- option to set mobile specific image src (e.g display a smaller logo for mobile view)
- option to hide logo for mobile view (declutter the navigation bar for mobile view where limited space is available)
- AT friendly pre-set display options for logo (pre-set includes `small`, `large` or `fill`. As these are applied as classes it gives scope for custom classes in FW projects however the pre-set should cover most use cases)
- documentation updated