### PR TITLE
Fix: Allow overrides on content objects (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Settings overview
 
-The image displays with minimal padding by default or can be configured to fill the navigation bar height. For mobile, an alternative, mobile-friendly image can be specified or the logo can be hidden entirely.
+The image displays with minimal padding by default or can be configured to fill the navigation bar height. For mobile, an alternative, mobile-friendly image can be specified or the logo can be hidden entirely. The logo can be shown on the menu, on specific pages, or everywhere.
 
 ## Attributes
 
-The following attributes are set within *course.json*.
+The following attributes are set within *course.json* or *contentObjects.json*.
 
 ### **\_navigationLogo** (object):
 The object that defines the content to render. It contains the following settings:
@@ -40,7 +40,6 @@ Optional, hide logo for mobile view. Useful to declutter the navigation bar wher
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.
 
 ----------------------------
-**Version number:**  2.1.0<br>
 **Framework versions:**  5.24.4+<br>
 **Author / maintainer:** CGKineo<br>
 **AAT support:** Yes<br>

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ The image displays with minimal padding by default or can be configured to fill 
 
 ## Attributes
 
-The following attributes are set within *course.json* or *contentObjects.json*.
+The following attributes are set within *course.json*.
 
 ### **\_navigationLogo** (object):
 The object that defines the content to render. It contains the following settings:
 
 ### **\_isEnabled** (boolean):
 Turns on and off the **Navigation Logo** extension.
+
+### **\_isHidden** (boolean):
+When `true`, hides the logo on the main menu. Default: `false`
 
 ### **\_graphic** (object):
 The graphic object that defines the image which is rendered. The assumed use case for this image is to display a client's logo. It contains the following settings:
@@ -35,6 +38,11 @@ Default: `false` where the image is displayed with minimal padding. Set to `true
 
 ### **\_hideLogoForMobile** (boolean):
 Optional, hide logo for mobile view. Useful to declutter the navigation bar where limited space is available.
+
+The following attributes are set within *contentObjects.json*.
+
+### **\_isHidden** (boolean):
+When `true`, hides the logo on a specific page or sub menu. Default: `false`
 
 ## Accessibility
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ Optional, hide logo for mobile view. Useful to declutter the navigation bar wher
 
 The following attributes are set within *contentObjects.json*.
 
+### **\_navigationLogo** (object):
+The object that defines the content to render. It contains the following settings:
+
 ### **\_isEnabled** (boolean):
-When `true`, shows the logo on a specific page or sub menu. Default: `true`
+When `false`, hides the logo on a specific page or sub menu. Default: `true`
 
 ## Accessibility
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Optional, hide logo for mobile view. Useful to declutter the navigation bar wher
 
 The following attributes are set within *contentObjects.json*.
 
-### **\_isHidden** (boolean):
-When `true`, hides the logo on a specific page or sub menu. Default: `false`
+### **\_isEnabled** (boolean):
+When `true`, shows the logo on a specific page or sub menu. Default: `true`
 
 ## Accessibility
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Settings overview
 
-The image displays with minimal padding by default or can be configured to fill the navigation bar height. For mobile, an alternative, mobile-friendly image can be specified or the logo can be hidden entirely. The logo can be shown on the menu, on specific pages, or everywhere.
+The image displays with minimal padding by default or can be configured to fill the navigation bar height. For mobile, an alternative, mobile-friendly image can be specified or the logo can be hidden entirely. The logo can be shown on the menu, on specific pages, or everywhere as default.
 
 ## Attributes
 

--- a/example.json
+++ b/example.json
@@ -10,7 +10,7 @@
     "_isEnabled": true,
     "_isHidden": false,
     "_graphic": {
-        "_src": "assets/example.png",
+        "src": "assets/example.png",
         "_mobileSrc": "",
         "alt": ""
     },

--- a/example.json
+++ b/example.json
@@ -10,7 +10,7 @@
     "_isEnabled": true,
     "_isHidden": false,
     "_graphic": {
-        "src": "assets/example.png",
+        "_src": "assets/example.png",
         "_mobileSrc": "",
         "alt": ""
     },
@@ -20,5 +20,5 @@
 
 // contentObjects.json
 "_navigationLogo": {
-    "_isHidden": false
+    "_isEnabled": true
 }

--- a/example.json
+++ b/example.json
@@ -6,6 +6,7 @@
         }
     }
 }
+// Enable global logo
 "_navigationLogo": {
     "_isEnabled": true,
     "_isHidden": false,
@@ -18,7 +19,7 @@
     "_hideLogoForMobile": true
 }
 
-// contentObjects.json
+// contentObjects.json - Disable for this page
 "_navigationLogo": {
-    "_isEnabled": true
+    "_isEnabled": false
 }

--- a/example.json
+++ b/example.json
@@ -1,6 +1,14 @@
-// course.json or contentObjects.json
+// course.json
+"_globals": {
+    "_extensions": {
+        "_navigationLogo": {
+            "_navOrder": 1
+        }
+    }
+}
 "_navigationLogo": {
     "_isEnabled": true,
+    "_isHidden": false,
     "_graphic": {
         "src": "assets/example.png",
         "_mobileSrc": "",
@@ -10,10 +18,7 @@
     "_hideLogoForMobile": true
 }
 
-"_globals": {
-    "_extensions": {
-        "_navigationLogo": {
-            "_navOrder": 1
-        }
-    }
+// contentObjects.json
+"_navigationLogo": {
+    "_isHidden": false
 }

--- a/example.json
+++ b/example.json
@@ -1,4 +1,4 @@
-// course.json
+// course.json or contentObjects.json
 "_navigationLogo": {
     "_isEnabled": true,
     "_graphic": {

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -27,8 +27,8 @@ class NavigationLogoView extends Backbone.View {
 
   changed() {
     this.setIsDeviceSmall();
-    this.setLogoImageSrc();
-    this.setLogoImageAlt();
+    this.setLogoSrc();
+    this.setLogoAlt();
     this.hideForMobile();
 
     ReactDOM.render(<templates.navigationLogo {...this.model.toJSON()} />, this.el);
@@ -38,7 +38,7 @@ class NavigationLogoView extends Backbone.View {
     this.model.set('_isDeviceSmall', device.screenSize === 'small');
   }
 
-  setLogoImageSrc() {
+  setLogoSrc() {
     let src;
 
     // Course config
@@ -62,7 +62,7 @@ class NavigationLogoView extends Backbone.View {
     this.model.set('src', graphic._mobileSrc);
   }
 
-  setLogoImageAlt() {
+  setLogoAlt() {
     let alt;
 
     // Course config

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -39,44 +39,27 @@ class NavigationLogoView extends Backbone.View {
   }
 
   setLogoSrc() {
-    let src;
-
     // Course config
     const courseConfig = Adapt.course.get('_navigationLogo');
-    if (courseConfig?._graphic?._src) {
-      src = courseConfig._graphic._src;
-    }
+    if (!courseConfig?._graphic?._src) return;
 
-    // Allow override per content object
-    const thisConfig = this.model.get('_navigationLogo');
-    if (thisConfig?._graphic?._src) {
-      src = this.model.get('_graphic')._src;
-    }
-
+    const src = courseConfig._graphic._src;
     this.model.set('src', src);
 
     // Check for mobile graphic
     const _isDeviceSmall = this.model.get('_isDeviceSmall');
-    if (!_isDeviceSmall || !graphic._mobileSrc) return;
+    if (!_isDeviceSmall || !courseConfig._graphic?._mobileSrc) return;
 
-    this.model.set('src', graphic._mobileSrc);
+    const mobileSrc = courseConfig._graphic._mobileSrc;
+    this.model.set('src', mobileSrc);
   }
 
   setLogoAlt() {
-    let alt;
-
     // Course config
     const courseConfig = Adapt.course.get('_navigationLogo');
-    if (courseConfig?._graphic?.alt) {
-      alt = courseConfig._graphic.alt;
-    }
+    if (!courseConfig?._graphic?.alt) return;
 
-    // Allow override per content object
-    const thisConfig = this.model.get('_navigationLogo');
-    if (thisConfig?._graphic?.alt) {
-      alt = this.model.get('_graphic').alt;
-    }
-
+    const alt = courseConfig._graphic.alt;
     this.model.set('alt', alt);
   }
 

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -28,6 +28,7 @@ class NavigationLogoView extends Backbone.View {
   changed() {
     this.setIsDeviceSmall();
     this.setLogoImageSrc();
+    this.setLogoImageAlt();
     this.hideForMobile();
 
     ReactDOM.render(<templates.navigationLogo {...this.model.toJSON()} />, this.el);
@@ -38,13 +39,45 @@ class NavigationLogoView extends Backbone.View {
   }
 
   setLogoImageSrc() {
-    const _graphic = this.model.get('_graphic');
-    this.model.set('src', _graphic.src);
+    let src;
 
+    // Course config
+    const courseConfig = Adapt.course.get('_navigationLogo');
+    if (courseConfig?._graphic?._src) {
+      src = courseConfig._graphic._src;
+    }
+
+    // Allow override per content object
+    const thisConfig = this.model.get('_navigationLogo');
+    if (thisConfig?._graphic?._src) {
+      src = this.model.get('_graphic')._src;
+    }
+
+    this.model.set('src', src);
+
+    // Check for mobile graphic
     const _isDeviceSmall = this.model.get('_isDeviceSmall');
-    if (!_isDeviceSmall || !_graphic._mobileSrc) return;
+    if (!_isDeviceSmall || !graphic._mobileSrc) return;
 
-    this.model.set('src', _graphic._mobileSrc);
+    this.model.set('src', graphic._mobileSrc);
+  }
+
+  setLogoImageAlt() {
+    let alt;
+
+    // Course config
+    const courseConfig = Adapt.course.get('_navigationLogo');
+    if (courseConfig?._graphic?.alt) {
+      alt = courseConfig._graphic.alt;
+    }
+
+    // Allow override per content object
+    const thisConfig = this.model.get('_navigationLogo');
+    if (thisConfig?._graphic?.alt) {
+      alt = this.model.get('_graphic').alt;
+    }
+
+    this.model.set('alt', alt);
   }
 
   hideForMobile() {

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -41,9 +41,9 @@ class NavigationLogoView extends Backbone.View {
   setLogoSrc() {
     // Course config
     const courseConfig = Adapt.course.get('_navigationLogo');
-    if (!courseConfig?._graphic?._src) return;
+    if (!courseConfig?._graphic?.src) return;
 
-    const src = courseConfig._graphic._src;
+    const src = courseConfig._graphic.src;
     this.model.set('src', src);
 
     // Check for mobile graphic

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -9,11 +9,18 @@ class NavigationLogo extends Backbone.Controller {
     });
   }
 
+  static get courseConfig() {
+    return Adapt.course.get('_navigationLogo');
+  }
+
   onPostRender(view) {
     if (this.logoView) this.logoView.remove();
 
     const config = view.model.get('_navigationLogo');
-    if (!config || !config._isEnabled || config._isHidden) return;
+    if (
+      (!NavigationLogo.courseConfig || !NavigationLogo.courseConfig._isEnabled) ||
+      (config && (!config._isEnabled || config._isHidden))
+    ) return;
 
     const model = new Backbone.Model(config);
     this.logoView = new NavigationLogoView({ model });

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -13,7 +13,7 @@ class NavigationLogo extends Backbone.Controller {
     if (this.logoView) this.logoView.remove();
 
     const config = view.model.get('_navigationLogo');
-    if (!config || !config._isEnabled) return;
+    if (!config || !config._isEnabled || config._isHidden) return;
 
     const model = new Backbone.Model(config);
     this.logoView = new NavigationLogoView({ model });

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -4,13 +4,15 @@ import NavigationLogoView from './NavigationLogoView';
 class NavigationLogo extends Backbone.Controller {
 
   initialize() {
-    this.listenTo(Adapt, 'adapt:initialize', this.onDataReady);
+    this.listenTo(Adapt, {
+      'menuView:postRender pageView:postRender': this.onPostRender
+    });
   }
 
-  onDataReady() {
+  onPostRender(view) {
     if (this.logoView) this.logoView.remove();
 
-    const config = Adapt.course.get('_navigationLogo');
+    const config = view.model.get('_navigationLogo');
     if (!config || !config._isEnabled) return;
 
     const model = new Backbone.Model(config);

--- a/properties.schema
+++ b/properties.schema
@@ -36,6 +36,15 @@
                   "validators": [],
                   "help": ""
                 },
+                "_isHidden": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Hide the logo on the menu",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": ""
+                },
                 "_graphic": {
                   "type": "object",
                   "required": true,
@@ -101,67 +110,14 @@
               "required": false,
               "legend": "Navigation Logo",
               "properties": {
-                "_isEnabled": {
+                "_isHidden": {
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Add logo to navigation bar",
+                  "title": "Hide the logo on this page or sub menu",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": ""
-                },
-                "_graphic": {
-                  "type": "object",
-                  "required": true,
-                  "title": "Logo image",
-                  "properties": {
-                    "src": {
-                      "type": "string",
-                      "required": false,
-                      "default": "",
-                      "title": "Image",
-                      "inputType": "Asset:image",
-                      "validators": [],
-                      "help": "The provided logo must be 24px high minimum."
-                    },
-                    "_mobileSrc": {
-                      "type": "string",
-                      "required": false,
-                      "default": "",
-                      "title": "Optional mobile image",
-                      "inputType": "Asset:image",
-                      "validators": [],
-                      "help": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum."
-                    },
-                    "alt": {
-                      "type": "string",
-                      "required": false,
-                      "default": "",
-                      "title": "Logo image alternative text",
-                      "inputType": "Text",
-                      "validators": [],
-                      "help": "Provide alternative text for the image, such as your company name. This text is not a visible element. It is utilized by assistive technology such as screen readers. Avoid identifying the logo as actually being a logo.",
-                      "translatable": true
-                    }
-                  }
-                },
-                "_fillNavHeight": {
-                  "type": "boolean",
-                  "required": false,
-                  "default": false,
-                  "title": "Make logo fill navigation bar height",
-                  "inputType": "Checkbox",
-                  "validators": [],
-                  "help": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height."
-                },
-                "_hideLogoForMobile": {
-                  "type": "boolean",
-                  "required": false,
-                  "default": false,
-                  "title": "Hide logo for mobile view",
-                  "inputType": "Checkbox",
-                  "validators": [],
-                  "help": "Useful to declutter the navigation bar for mobile view where limited space is available."
                 }
               }
             }

--- a/properties.schema
+++ b/properties.schema
@@ -92,6 +92,80 @@
               }
             }
           }
+        },
+        "contentobject": {
+          "type": "object",
+          "properties": {
+            "_navigationLogo": {
+              "type": "object",
+              "required": false,
+              "legend": "Navigation Logo",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Add logo to navigation bar",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": ""
+                },
+                "_graphic": {
+                  "type": "object",
+                  "required": true,
+                  "title": "Logo image",
+                  "properties": {
+                    "src": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Image",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "The provided logo must be 24px high minimum."
+                    },
+                    "_mobileSrc": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Optional mobile image",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "help": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum."
+                    },
+                    "alt": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Logo image alternative text",
+                      "inputType": "Text",
+                      "validators": [],
+                      "help": "Provide alternative text for the image, such as your company name. This text is not a visible element. It is utilized by assistive technology such as screen readers. Avoid identifying the logo as actually being a logo.",
+                      "translatable": true
+                    }
+                  }
+                },
+                "_fillNavHeight": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Make logo fill navigation bar height",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height."
+                },
+                "_hideLogoForMobile": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Hide logo for mobile view",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Useful to declutter the navigation bar for mobile view where limited space is available."
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/properties.schema
+++ b/properties.schema
@@ -30,8 +30,8 @@
                 "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "default": false,
-                  "title": "Add logo to navigation bar",
+                  "default": true,
+                  "title": "Show logo on the navigation bar",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": ""
@@ -40,7 +40,7 @@
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Hide the logo on the menu",
+                  "title": "Hide the nav logo on the menu",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": ""
@@ -110,11 +110,11 @@
               "required": false,
               "legend": "Navigation Logo",
               "properties": {
-                "_isHidden": {
+                "_isEnabled": {
                   "type": "boolean",
                   "required": false,
-                  "default": false,
-                  "title": "Hide the logo on this page or sub menu",
+                  "default": true,
+                  "title": "Show nav logo on this page / sub menu",
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": ""

--- a/properties.schema
+++ b/properties.schema
@@ -50,7 +50,7 @@
                   "required": true,
                   "title": "Logo image",
                   "properties": {
-                    "_src": {
+                    "src": {
                       "type": "string",
                       "required": false,
                       "default": "",

--- a/properties.schema
+++ b/properties.schema
@@ -50,7 +50,7 @@
                   "required": true,
                   "title": "Logo image",
                   "properties": {
-                    "src": {
+                    "_src": {
                       "type": "string",
                       "required": false,
                       "default": "",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -1,0 +1,74 @@
+{
+  "$anchor": "navigationLogo-contentobject",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$patch": {
+    "source": {
+      "$ref": "contentobject"
+    },
+    "with": {
+      "properties": {
+        "_navigationLogo": {
+          "type": "object",
+          "title": "Navigation Logo",
+          "default": {},
+          "required": [],
+          "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "title": "Add logo to navigation bar",
+              "default": false
+            },
+            "_graphic": {
+              "type": "object",
+              "title": "Logo image",
+              "properties": {
+                "src": {
+                  "type": "string",
+                  "isObjectId": true,
+                  "title": "Image",
+                  "description": "The provided logo must be 24px high minimum.",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                },
+                "_mobileSrc": {
+                  "type": "string",
+                  "isObjectId": true,
+                  "title": "Optional mobile image",
+                  "description": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum.",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                },
+                "alt": {
+                  "type": "string",
+                  "title": "Logo image alternative text",
+                  "description": "Provide alternative text for the image, such as your company name. This text is not a visible element. It is utilized by assistive technology such as screen readers. Avoid identifying the logo as actually being a logo.",
+                  "default": "",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                }
+              }
+            },
+            "_fillNavHeight": {
+              "type": "boolean",
+              "title": "Make logo fill navigation bar height",
+              "description": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height.",
+              "default": false
+            },
+            "_hideLogoForMobile": {
+              "type": "boolean",
+              "title": "Hide logo for mobile view",
+              "description": "Useful to declutter the navigation bar for mobile view where limited space is available.",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -14,56 +14,9 @@
           "default": {},
           "required": [],
           "properties": {
-            "_isEnabled": {
+            "_isHidden": {
               "type": "boolean",
-              "title": "Add logo to navigation bar",
-              "default": false
-            },
-            "_graphic": {
-              "type": "object",
-              "title": "Logo image",
-              "properties": {
-                "src": {
-                  "type": "string",
-                  "isObjectId": true,
-                  "title": "Image",
-                  "description": "The provided logo must be 24px high minimum.",
-                  "_backboneForms": {
-                    "type": "Asset",
-                    "media": "image"
-                  }
-                },
-                "_mobileSrc": {
-                  "type": "string",
-                  "isObjectId": true,
-                  "title": "Optional mobile image",
-                  "description": "Useful for displaying a smaller logo for mobile view. The provided logo must be 24px high minimum.",
-                  "_backboneForms": {
-                    "type": "Asset",
-                    "media": "image"
-                  }
-                },
-                "alt": {
-                  "type": "string",
-                  "title": "Logo image alternative text",
-                  "description": "Provide alternative text for the image, such as your company name. This text is not a visible element. It is utilized by assistive technology such as screen readers. Avoid identifying the logo as actually being a logo.",
-                  "default": "",
-                  "_adapt": {
-                    "translatable": true
-                  }
-                }
-              }
-            },
-            "_fillNavHeight": {
-              "type": "boolean",
-              "title": "Make logo fill navigation bar height",
-              "description": "Logo displays with minimal padding by default. Set to true for logo to fill the nav bar height.",
-              "default": false
-            },
-            "_hideLogoForMobile": {
-              "type": "boolean",
-              "title": "Hide logo for mobile view",
-              "description": "Useful to declutter the navigation bar for mobile view where limited space is available.",
+              "title": "Hide the logo on this page or sub menu",
               "default": false
             }
           }

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -14,10 +14,10 @@
           "default": {},
           "required": [],
           "properties": {
-            "_isHidden": {
+            "_isEnabled": {
               "type": "boolean",
-              "title": "Hide the logo on this page or sub menu",
-              "default": false
+              "title": "Show nav logo on this page / sub menu",
+              "default": true
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -50,7 +50,7 @@
               "type": "object",
               "title": "Logo image",
               "properties": {
-                "_src": {
+                "src": {
                   "type": "string",
                   "isObjectId": true,
                   "title": "Image",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -38,12 +38,12 @@
           "properties": {
             "_isEnabled": {
               "type": "boolean",
-              "title": "Add logo to navigation bar",
-              "default": false
+              "title": "Show logo on the navigation bar",
+              "default": true
             },
             "_isHidden": {
               "type": "boolean",
-              "title": "Hide the logo on the menu",
+              "title": "Hide the nav logo on the menu",
               "default": false
             },
             "_graphic": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -50,7 +50,7 @@
               "type": "object",
               "title": "Logo image",
               "properties": {
-                "src": {
+                "_src": {
                   "type": "string",
                   "isObjectId": true,
                   "title": "Image",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -41,6 +41,11 @@
               "title": "Add logo to navigation bar",
               "default": false
             },
+            "_isHidden": {
+              "type": "boolean",
+              "title": "Hide the logo on the menu",
+              "default": false
+            },
             "_graphic": {
               "type": "object",
               "title": "Logo image",

--- a/templates/navigationLogo.jsx
+++ b/templates/navigationLogo.jsx
@@ -3,8 +3,8 @@ import { classes } from 'core/js/reactHelpers';
 
 export default function NavigationLogo(props) {
   const {
-    _graphic,
     src,
+    alt,
     _fillNavHeight
   } = props;
 
@@ -19,8 +19,8 @@ export default function NavigationLogo(props) {
       <img
         className='navigation-logo__image'
         src={src}
-        aria-label={_graphic.alt || null}
-        aria-hidden={!_graphic.alt || null}
+        aria-label={alt || null}
+        aria-hidden={!alt || null}
       />
     </div>
 


### PR DESCRIPTION
Fixes #12 

### Fix
* Adds `_isHidden` option to hide the logo on the main menu (in _course.json_)
* Content objects will inherit logo's `_src` and `alt` values from _course.json_
* Removes version number from README.md