### PR TITLE
Update: Rename isHidden property to isHiddenOnMenu for clarity (fixes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The object that defines the content to render. It contains the following setting
 ### **\_isEnabled** (boolean):
 Turns on and off the **Navigation Logo** extension.
 
-### **\_isHidden** (boolean):
+### **\_isHiddenOnMenu** (boolean):
 When `true`, hides the logo on the main menu. Default: `false`
 
 ### **\_graphic** (object):

--- a/example.json
+++ b/example.json
@@ -9,7 +9,7 @@
 // Enable global logo
 "_navigationLogo": {
     "_isEnabled": true,
-    "_isHidden": false,
+    "_isHiddenOnMenu": false,
     "_graphic": {
         "src": "assets/example.png",
         "_mobileSrc": "",

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -19,7 +19,7 @@ class NavigationLogo extends Backbone.Controller {
     const config = view.model.get('_navigationLogo');
     if (
       (!NavigationLogo.courseConfig || !NavigationLogo.courseConfig._isEnabled) ||
-      (config && (!config._isEnabled || config._isHidden))
+      (config && (!config._isEnabled || config._isHiddenOnMenu))
     ) return;
 
     const model = new Backbone.Model(config);

--- a/properties.schema
+++ b/properties.schema
@@ -36,7 +36,7 @@
                   "validators": [],
                   "help": ""
                 },
-                "_isHidden": {
+                "_isHiddenOnMenu": {
                   "type": "boolean",
                   "required": false,
                   "default": false,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -47,7 +47,7 @@
               "title": "Show logo on the navigation bar",
               "default": true
             },
-            "_isHidden": {
+            "_isHiddenOnMenu": {
               "type": "boolean",
               "title": "Hide the nav logo on the menu",
               "default": false


### PR DESCRIPTION
Fixes #17 

### Fix
* Renames `_isHidden` to `_isHiddenOnMenu` for clarity

### Backwards compatibility
In a build, `_isHidden` should be replaced with `_isHiddenOnMenu` or the logo will _always_ appear on the menu. Otherwise, this is not a breaking change (please let me know if you disagree!)