### PR TITLE
Fix: Inherit _fillNavHeight on content objects, change height calculation (fixes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,46 +8,58 @@
 
 The image displays with minimal padding by default or can be configured to fill the navigation bar height. For mobile, an alternative, mobile-friendly image can be specified or the logo can be hidden entirely. The logo can be shown on the menu, on specific pages, or everywhere as default.
 
-### Attributes
+## Attributes
 
-The following attributes are set within _course.json_.
+The following attributes are set within *course.json*.
 
-**\_navigationLogo** (object):
+### **\_navigationLogo** (object)
+
 The object that defines the content to render. It contains the following settings:
 
-> **\_isEnabled** (boolean):
+#### **\_isEnabled** (boolean)
+
 Turns on and off the **Navigation Logo** extension.
 
-> **\_isHiddenOnMenu** (boolean):
+#### **\_isHiddenOnMenu** (boolean)
+
 When `true`, hides the logo on the main menu. Default: `false`
 
-> **\_graphic** (object):
+#### **\_graphic** (object)
+
 The graphic object that defines the image which is rendered. The assumed use case for this image is to display a client's logo. It contains the following settings:
 
->> **src** (string):
+##### **src** (string)
+
 File name (including path) of the image. Path should be relative to the `src` folder (e.g. "course/en/images/logo.jpg").
 
->> **\_mobileSrc** (string):
+##### **\_mobileSrc** (string)
+
 Optional, file name (including path) of the image. Used to display an alternative image for mobile view. Useful for displaying a smaller logo.
 
->> **alt** (string):
+##### **alt** (string)
+
 This text becomes the image’s [alt](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) attribute.
 
-> **\_fillNavHeight** (boolean):
+#### **\_fillNavHeight** (boolean)
+
 Default: `false` where the image is displayed with minimal padding. Set to `true` for the image to fill the nav bar height.
 
-> **\_hideLogoForMobile** (boolean):
+#### **\_hideLogoForMobile** (boolean)
+
 Optional, hide logo for mobile view. Useful to declutter the navigation bar where limited space is available.
 
-The following attributes are set within _contentObjects.json_.
+The following attributes are set within *contentObjects.json*.
 
-**\_navigationLogo** (object):
+### **\_navigationLogo** (object)
+
 The object that defines the content to render. It contains the following settings:
 
-> **\_isEnabled** (boolean):
+#### **\_isEnabled** (boolean)
+
 When `false`, hides the logo on a specific page or sub menu. Default: `true`
 
-### Accessibility
+## Accessibility
+
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.
 
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ When `false`, hides the logo on a specific page or sub menu. Default: `true`
 Remember to include an `alt` attribute. Screen readers will read aloud alt text content, so leave the alt text empty (`"alt": ""`) if the logo is repeated in the course title.
 
 ----------------------------
-**Framework versions:**  5.24.4+<br>
 **Author / maintainer:** CGKineo<br>
 **AAT support:** Yes<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-navigationLogo",
   "version": "3.1.1",
-  "framework": ">=5",
+  "framework": ">=5.30.3",
   "homepage": "https://github.com/cgkineo/adapt-navigationLogo",
   "bugs": "https://github.com/cgkineo/adapt-navigationLogo/issues",
   "extension": "navigationLogo",

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -21,6 +21,10 @@ class NavigationLogoView extends Backbone.View {
     this.render();
   }
 
+  static get courseConfig() {
+    return Adapt.course.get('_navigationLogo');
+  }
+
   render() {
     this.changed();
   }
@@ -39,35 +43,29 @@ class NavigationLogoView extends Backbone.View {
   }
 
   setLogoSrc() {
-    // Course config
-    const courseConfig = Adapt.course.get('_navigationLogo');
-    if (!courseConfig?._graphic?.src) return;
+    if (!NavigationLogoView.courseConfig ?._graphic?.src) return;
 
-    const src = courseConfig._graphic.src;
+    const src = NavigationLogoView.courseConfig._graphic.src;
     this.model.set('src', src);
 
     // Check for mobile graphic
     const _isDeviceSmall = this.model.get('_isDeviceSmall');
-    if (!_isDeviceSmall || !courseConfig._graphic?._mobileSrc) return;
+    if (!_isDeviceSmall || !NavigationLogoView.courseConfig._graphic?._mobileSrc) return;
 
-    const mobileSrc = courseConfig._graphic._mobileSrc;
+    const mobileSrc = NavigationLogoView.courseConfig._graphic._mobileSrc;
     this.model.set('src', mobileSrc);
   }
 
   setLogoAlt() {
-    // Course config
-    const courseConfig = Adapt.course.get('_navigationLogo');
-    if (!courseConfig?._graphic?.alt) return;
+    if (!NavigationLogoView.courseConfig?._graphic?.alt) return;
 
-    const alt = courseConfig._graphic.alt;
+    const alt = NavigationLogoView.courseConfig._graphic.alt;
     this.model.set('alt', alt);
   }
 
   hideForMobile() {
     const _isDeviceSmall = this.model.get('_isDeviceSmall');
-
-    const courseConfig = Adapt.course.get('_navigationLogo');
-    const _hideLogoForMobile = courseConfig._hideLogoForMobile;
+    const _hideLogoForMobile = NavigationLogoView.courseConfig._hideLogoForMobile;
 
     if (_isDeviceSmall && _hideLogoForMobile) {
       this.$el.addClass('u-display-none');

--- a/js/adapt-navigationLogo.js
+++ b/js/adapt-navigationLogo.js
@@ -23,6 +23,7 @@ class NavigationLogo extends Backbone.Controller {
     ) return;
 
     const model = new Backbone.Model(config);
+    model.set('_fillNavHeight', NavigationLogo.courseConfig._fillNavHeight);
     this.logoView = new NavigationLogoView({ model });
 
     const selector = '.js-nav-back-btn';

--- a/less/navigationLogo.less
+++ b/less/navigationLogo.less
@@ -11,6 +11,6 @@
 
   // fill nav height display
   .is-fill &__image {
-    height: @icon-size + (@icon-padding * 2);
+    height: var(--adapt-navigation-height);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-navigationLogo",
   "version": "3.1.1",
-  "framework": ">=5",
+  "framework": ">=5.30.3",
   "homepage": "https://github.com/cgkineo/adapt-navigationLogo",
   "bugs": "https://github.com/cgkineo/adapt-navigationLogo/issues",
   "extension": "navigationLogo",


### PR DESCRIPTION
Fix #22 

### Fix
* Ensures that content objects inherit `_fillNavHeight` from _course.json_ configuration.

### Update
* Use `--adapt-navigation-height` for logo height when using fill height
* Change required FW version to 5.30.3

### Testing
See #22 