### PR TITLE
Update: left align nav logo by default (fixes #24)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -8,7 +8,7 @@
       "type": "number",
       "required": true,
       "title": "Navigation bar order",
-      "default": 1,
+      "default": 0,
       "inputType": "Text",
       "help": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
       "validators": []

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -25,7 +25,7 @@
                       "type": "number",
                       "title": "Navigation bar order",
                       "description": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
-                      "default": 1,
+                      "default": 0,
                       "_backboneForms": "Number"
                     }
                   }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-navigationLogo/issues/24

Typically, the nav logo is positioned to the left side of the screen (for RTL) courses. Set `_navOrder` default to `0` so the default display is left aligned.

![suggested_order](https://github.com/cgkineo/adapt-navigationLogo/assets/7045330/f20fd3e2-1a3a-4c7c-898f-50beb1fd9635)
