### PR TITLE
New: Add logo link option (fixes #26)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Optional, file name (including path) of the image. Used to display an alternativ
 
 This text becomes the image’s [alt](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) attribute.
 
+#### **_routeToLocation** (string)
+
+When set to a valid Adapt element, the logo image will link to the specified location. Valid values include a page (e.g. `co-100`) or a menu (e.g. `course`)
+
 #### **\_fillNavHeight** (boolean)
 
 Default: `false` where the image is displayed with minimal padding. Set to `true` for the image to fill the nav bar height.

--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
         "_mobileSrc": "",
         "alt": ""
     },
+    "_routeToLocation": "",
     "_fillNavHeight": false,
     "_hideLogoForMobile": true
 }

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -1,5 +1,7 @@
 import Adapt from 'core/js/adapt';
+import data from 'core/js/data';
 import device from 'core/js/device';
+import router from 'core/js/router';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { templates } from 'core/js/reactHelpers';
@@ -7,7 +9,10 @@ import { templates } from 'core/js/reactHelpers';
 class NavigationLogoView extends Backbone.View {
 
   className() {
-    return 'navigation-logo';
+    return [
+      'navigation-logo',
+      NavigationLogoView.courseConfig._routeToLocation && 'has-link'
+    ].filter(Boolean).join(' ');
   }
 
   attributes() {
@@ -16,8 +21,15 @@ class NavigationLogoView extends Backbone.View {
     };
   }
 
+  events() {
+    return {
+      click: 'navigateToLocation'
+    };
+  }
+
   initialize() {
     this.listenTo(Adapt, 'device:changed', this.changed);
+    this.navigateToLocation = this.navigateToLocation.bind(this);
     this.render();
   }
 
@@ -43,7 +55,7 @@ class NavigationLogoView extends Backbone.View {
   }
 
   setLogoSrc() {
-    if (!NavigationLogoView.courseConfig ?._graphic?.src) return;
+    if (!NavigationLogoView.courseConfig?._graphic?.src) return;
 
     const src = NavigationLogoView.courseConfig._graphic.src;
     this.model.set('src', src);
@@ -71,6 +83,24 @@ class NavigationLogoView extends Backbone.View {
       this.$el.addClass('u-display-none');
     } else {
       this.$el.removeClass('u-display-none');
+    }
+  }
+
+  navigateToLocation() {
+    const redirectToId = NavigationLogoView.courseConfig._routeToLocation;
+    if (!redirectToId) return;
+
+    const model = data.findById(redirectToId);
+    if (!model) return;
+
+    switch (model.get('_type')) {
+      case 'course':
+        router.navigateToHomeRoute();
+        break;
+      case 'menu':
+      case 'page':
+        router.navigateToElement(model.get('_id'));
+        break;
     }
   }
 };

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
 import device from 'core/js/device';
+import location from 'core/js/location';
 import router from 'core/js/router';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -99,12 +100,15 @@ class NavigationLogoView extends Backbone.View {
     const model = data.findById(redirectToId);
     if (!model) return;
 
+    const currentLocation = location._currentId;
     switch (model.get('_type')) {
       case 'course':
+        if (currentLocation === 'course') return;
         router.navigateToHomeRoute();
         break;
       case 'menu':
       case 'page':
+        if (currentLocation === model.get('_id')) return;
         router.navigateToElement(model.get('_id'));
         break;
     }

--- a/js/NavigationLogoView.js
+++ b/js/NavigationLogoView.js
@@ -17,13 +17,16 @@ class NavigationLogoView extends Backbone.View {
 
   attributes() {
     return {
-      'data-order': (Adapt.course.get('_globals')?._extensions?._navigationLogo?._navOrder || 0)
+      'data-order': (Adapt.course.get('_globals')?._extensions?._navigationLogo?._navOrder || 0),
+      role: NavigationLogoView.courseConfig._routeToLocation && 'link',
+      tabindex: NavigationLogoView.courseConfig._routeToLocation && 0
     };
   }
 
   events() {
     return {
-      click: 'navigateToLocation'
+      click: 'navigateToLocation',
+      keydown: 'navigateToLocation'
     };
   }
 
@@ -86,9 +89,12 @@ class NavigationLogoView extends Backbone.View {
     }
   }
 
-  navigateToLocation() {
+  navigateToLocation(event) {
     const redirectToId = NavigationLogoView.courseConfig._routeToLocation;
     if (!redirectToId) return;
+
+    if (event.code && !['Space', 'Enter'].includes(event.code)) return;
+    if (event?.preventDefault) event.preventDefault();
 
     const model = data.findById(redirectToId);
     if (!model) return;

--- a/less/navigationLogo.less
+++ b/less/navigationLogo.less
@@ -13,4 +13,8 @@
   .is-fill &__image {
     height: var(--adapt-navigation-height);
   }
+
+  &.has-link {
+    cursor: pointer;
+  }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -80,6 +80,14 @@
                     }
                   }
                 },
+                "_routeToLocation": {
+                  "type": "string",
+                  "title": "Link",
+                  "help": "When set to a valid Adapt element, the logo image will link to the specified location. Valid values include a page (e.g. co-100) or a menu (e.g. course)",
+                  "required": false,
+                  "validators": [],
+                  "default": ""
+                },
                 "_fillNavHeight": {
                   "type": "boolean",
                   "required": false,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -87,6 +87,12 @@
                 }
               }
             },
+            "_routeToLocation": {
+              "type": "string",
+              "title": "Link",
+              "description": "When set to a valid Adapt element, the logo image will link to the specified location. Valid values include a page (e.g. co-100) or a menu (e.g. course)",
+              "default": ""
+            },
             "_fillNavHeight": {
               "type": "boolean",
               "title": "Make logo fill navigation bar height",


### PR DESCRIPTION
Fixes #26

### New
* Adds the `_routeToLocation` option to make the logo image a link

### Testing
1. Add a valid Adapt value for `_routeToLocation` as shown in the example.json.
2. Click on the link or tab to the link via keyboard and activate it with space or enter.